### PR TITLE
Add checks for sapling stage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.BlackBeltPanda</groupId>
     <artifactId>TwerkFarm</artifactId>
-    <version>1.1</version>
+    <version>1.2</version>
     <packaging>jar</packaging>
 
     <name>TwerkFarm</name>
@@ -15,7 +15,7 @@
     <properties>
         <maven.compiler.source>16</maven.compiler.source>
         <maven.compiler.target>16</maven.compiler.target>
-        <java.version>16</java.version>
+        <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <url>https://github.com/BlackBeltPanda</url>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.17-R0.1-SNAPSHOT</version>
+            <version>1.21.8-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/blackbeltpanda/twerkfarm/PlayerEvents.java
+++ b/src/main/java/com/blackbeltpanda/twerkfarm/PlayerEvents.java
@@ -45,6 +45,11 @@ public record PlayerEvents(Settings settings) implements Listener {
                         if (!(check.getState().getBlockData() instanceof Ageable ageable && ageable.getAge() >= ageable.getMaximumAge())) {
                             found.add(check);
                         }
+                        // Need to add this for Mangrove Propagules - There might be a better way to do this
+                        else if
+                            (!(check.getState().getBlockData() instanceof Sapling sapling && sapling.getStage() >= sapling.getMaximumStage())) {
+                            found.add(check);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Mangrove's by default have max age thus fail the check for age = maxage as it will always be true.

This also upgrades the plugin to 1.21.8 - Tested loads & functions